### PR TITLE
TST: Unit test for unsupported vector dimension handling by centroid

### DIFF
--- a/flecsale/geom/test/centroid.cc
+++ b/flecsale/geom/test/centroid.cc
@@ -55,3 +55,17 @@ TEST(centroid, 2d)
   ASSERT_NEAR( 0.5, cx2[1], test_tolerance ) << " Centroid calculation wrong ";
 
 } // TEST
+
+/* Test that centroid operator correctly handles unsupported
+ * input vector dimensionalities */
+using point_3d_t = point<real_t, 3>;
+using point_5d_t = point<real_t, 5>;
+
+TEST(centroid, HandlesUnsupportedDims)
+{
+  vector<point_3d_t> points_3d = { {0, 0, 0}, {1, 0, 7} };
+  vector<point_5d_t> points_5d = { {2, 0, 9, 0, 3}, {8 ,7, 9, 0, 7} };
+
+  ASSERT_THROW( centroid( points_3d ), ExceptionNotImplemented);
+  ASSERT_THROW( centroid( points_5d ), ExceptionNotImplemented);
+} // TEST

--- a/flecsale/geom/test/centroid.cc
+++ b/flecsale/geom/test/centroid.cc
@@ -10,6 +10,9 @@
 ///
 ////////////////////////////////////////////////////////////////////////////////
 
+// preprocessor directive for exception handling
+#define ENABLE_EXCEPTIONS
+
 // system includes
 #include<cinchtest.h>
 #include<vector>
@@ -34,6 +37,9 @@ using common::test_tolerance;
 
 //! the point type
 using point_2d_t = point<real_t, 2>;
+
+//! the error types used
+using utils::ExceptionNotImplemented;
 
 //=============================================================================
 //! \brief Test centroid operator.


### PR DESCRIPTION
This PR attempts to add a unit test that verifies the correct handling of unsupported input vector shapes (numbers of dimensions) by the `centroid` operator.

Note that although I'm comfortable writing in C, this is my first attempt at writing C++ code and using the associated googletest suite, so please do check it carefully. Indeed, I'm not clear on how to run the test suite locally for i.e., an isolated source file so I've not checked to see if this new test works yet -- perhaps the CI provides suitable feedback in this regard?