### PR TITLE
ENH: unify vertex creation code for 2D & 3D create_cells

### DIFF
--- a/apps/common/specialization_init.h
+++ b/apps/common/specialization_init.h
@@ -178,6 +178,28 @@ auto color_entity(
   entity_color_info.ghost = entities.ghost.size();
 }
 
+// 2D and 3D versions of create_cells function templates
+// both use identical procedures to create vertices
+template<
+  typename MESH_DEFINITION,
+  typename MESH_TYPE
+>
+void vertex_creation ( auto vertices,
+                       MESH_TYPE && mesh,
+                       MESH_DEFINITION && mesh_def,
+                       auto vertex_lid_to_mid)
+{
+  using mesh_t = typename std::decay_t< MESH_TYPE >;
+  using point_t = typename mesh_t::point_t;
+
+  for(auto & vm: vertex_lid_to_mid) {
+    // get the point
+    const auto & p = mesh_def.template vertex<point_t>( vm.second );
+    // now create it
+    auto v = mesh.create_vertex( p );
+    vertices.emplace_back(v);
+  } // for
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 /// \brief Helper function to create the cells
@@ -236,13 +258,10 @@ void create_cells( MESH_DEFINITION && mesh_def, MESH_TYPE && mesh )
   std::vector< vertex_t * > vertices;
   vertices.reserve( vertex_lid_to_mid.size() );
 
-  for(auto & vm: vertex_lid_to_mid) { 
-    // get the point
-    const auto & p = mesh_def.template vertex<point_t>( vm.second );
-    // now create it
-    auto v = mesh.create_vertex( p );
-    vertices.emplace_back(v);
-  } // for vertices
+  vertex_creation ( vertices,
+                    mesh,
+                    mesh_def,
+                    vertex_lid_to_mid);
 
   //----------------------------------------------------------------------------
   // create the cells
@@ -330,14 +349,10 @@ void create_cells( MESH_DEFINITION && mesh_def, MESH_TYPE && mesh )
   std::vector< vertex_t * > vertices;
   vertices.reserve( vertex_lid_to_mid.size() );
 
-  for(auto & vm: vertex_lid_to_mid) { 
-    // get the point
-    const auto & p = mesh_def.template vertex<point_t>( vm.second );
-    // now create it
-    auto v = mesh.create_vertex( p );
-    vertices.emplace_back(v);
-  } // for vertices
-
+  vertex_creation ( vertices,
+                    mesh,
+                    mesh_def,
+                    vertex_lid_to_mid);
 
   //----------------------------------------------------------------------------
   // create the faces


### PR DESCRIPTION
The 2D and 3D versions of the `create_cells` function templates both use a lot of the same code. I thought I'd try to reduce the code duplication for the identical procedures used to create the vertices in each function template by abstracting that code to another function that both 2D & 3D templates can call (to i.e., reduce maintenance burden).

Of course, the primary objective here is just to get familiar with the code base / c++ & the source file touched here also contains the corners & wedges that I'm eventually slotted to work on.

Since the tests aren't functional on the master branch (as discussed), I only have the successful compilation of the changes in this PR to go by and (hopefully) review comments.